### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,4 @@ Prometheus Operator as well. Since the targeted platform - OpenShift already
 has a Prometheus Operator, installing updated CRDs from newer version can
 potentially break the platform. Hence this fork was created as workaround for
 shipping newer version of Prometheus Operator without impacting on installed on
-platfrom.
-
-
+platform.


### PR DESCRIPTION
This PR fixes a small typo in the README.md file and remove blank
spaces.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>