### PR TITLE
COO-5: disable custom config deprecation flag

### DIFF
--- a/rhobs/olm/manifests/operator/kustomization.yaml
+++ b/rhobs/olm/manifests/operator/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
                 image: <IMG_PROMETHEUS_OPERATOR>
                 args:
                   - --prometheus-config-reloader=<IMG_PROMETHEUS_CONFIG_RELOADER>
+                  # Refer https://github.com/prometheus-operator/prometheus-operator/pull/6955
+                  - --disable-unmanaged-prometheus-configuration
                 resources:
                   requests:
                     cpu: 5m


### PR DESCRIPTION
Disable the custom config deprecation behavior flag to enable OBO to drop service discovery entirely.

JIRA: https://issues.redhat.com/browse/COO-5